### PR TITLE
Routes and Path Helpers

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,11 +1,11 @@
 <h2>Welcome to the Book Nook!</h2>
 
-<a href="/books?ratings=high" id="rating-high">Sort by: Highest Rating</a>
-<a href="/books?ratings=low" id="rating-low">Sort by: Lowest Rating</a>
-<a href="/books?pages=high" id="pages-high">Sort by: Most Pages</a>
-<a href="/books?pages=low" id="pages-low">Sort by: Least Pages</a>
-<a href="/books?reviews=high" id="reviews-high">Sort by: Most Reviews</a>
-<a href="/books?reviews=low" id="reviews-low">Sort by: Least Reviews</a>
+<a href=<%= books_path(ratings: "high") %> id="rating-high">Sort by: Highest Rating</a>
+<a href=<%= books_path(ratings: "low") %> id="rating-low">Sort by: Lowest Rating</a>
+<a href=<%= books_path(pages: "high") %> id="pages-high">Sort by: Most Pages</a>
+<a href=<%= books_path(pages: "low") %> id="pages-low">Sort by: Least Pages</a>
+<a href=<%= books_path(reviews: "high") %> id="reviews-high">Sort by: Most Reviews</a>
+<a href=<%= books_path(reviews: "low") %> id="reviews-low">Sort by: Least Reviews</a>
 
 <% @books.each do |book| %>
   <section class="book" id="book-<%= book.id %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,10 @@
 Rails.application.routes.draw do
-  get '/books', to: 'books#index'
+
+  resources :books do
+    resources :reviews, except: [:index, :show, :edit, :update]
+  end
+
+  resources :authors
+
+  resources :users, only: [:show, :create]
 end

--- a/spec/features/books/index_spec.rb
+++ b/spec/features/books/index_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "As a user", type: :feature do
     end
 
     it "I see all book titles in the database" do
-      visit '/books'
+      visit books_path
 
       within("#book-#{@book_1.id}") do
         expect(page).to have_css("img[src='#{@book_1.image}']")
@@ -46,7 +46,7 @@ RSpec.describe "As a user", type: :feature do
 
       within("#book-#{@book_3.id}") do
         expect(page).to have_css("img[src='#{@book_3.image}']")
-        
+
         expect(page).to have_content(@book_3.title)
         expect(page).to have_content(@book_3.authors[0].name)
         expect(page).to have_content(@book_3.pages)
@@ -55,7 +55,7 @@ RSpec.describe "As a user", type: :feature do
     end
 
     it "I see an average review rating and amount of reviews on each book" do
-      visit '/books'
+      visit books_path
 
       within("#book-#{@book_1.id}") do
         expect(page).to have_content("Average Rating: 4.0 (2)")
@@ -72,7 +72,7 @@ RSpec.describe "As a user", type: :feature do
 
     describe "I see sorting methods" do
       it "to sort by average rating" do
-        visit '/books'
+        visit books_path
 
         click_link 'Sort by: Lowest Rating'
 
@@ -86,7 +86,7 @@ RSpec.describe "As a user", type: :feature do
       end
 
       it "to sorts by number of pages" do
-        visit '/books'
+        visit books_path
 
         click_link 'Sort by: Most Pages'
 
@@ -102,7 +102,7 @@ RSpec.describe "As a user", type: :feature do
       it "to sorts by number of reviews" do
         review_5 = @book_2.reviews.create!(text: "THIS BOOK IS!", rating: 5, user: @user_1)
         review_6 = @book_1.reviews.create!(text: "BOOK!", rating: 5, user: @user_2)
-        visit '/books'
+        visit books_path
 
         click_link 'Sort by: Most Reviews'
 


### PR DESCRIPTION
This PR brings in the `books_path` helper to replace instances of calling on `'/books'` directly. We updated this in the Books Index spec where we were visiting the index directly, and also in the Index file where we were sending our sorting params to the controller. 
We also laid out our Resource paths, including Reviews being nested inside of a Book. It doesn't make any sense for a Review to not be viewed in the context of a Book.