### PR TITLE
Book Title Links

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -10,7 +10,7 @@
 <% @books.each do |book| %>
   <section class="book" id="book-<%= book.id %>">
     <img src="<%= book.image %>" alt="<%= book.title %> Cover">
-    <h5><%= book.title %></h5>
+    <h5><%= link_to book.title, book_path(book) %></h5>
     <p>Average Rating: <%= book.average_rating %> (<%= book.review_count %>)</p>
     <p><%= book.author_names.join(", ") %></p>
     <p>Pages: <%= book.pages %></p>

--- a/spec/features/books/index_spec.rb
+++ b/spec/features/books/index_spec.rb
@@ -54,6 +54,32 @@ RSpec.describe "As a user", type: :feature do
       end
     end
 
+    it "I see that each book title is a link" do
+      visit books_path
+
+      within("#book-#{@book_1.id}") do
+        expect(page).to have_link(@book_1.title)
+      end
+
+      within("#book-#{@book_2.id}") do
+        expect(page).to have_link(@book_2.title)
+      end
+
+      within("#book-#{@book_3.id}") do
+        expect(page).to have_link(@book_3.title)
+      end
+    end
+
+    it "I'm able to navigate to a book's show page by clicking the title" do
+      visit books_path
+
+      within("#book-#{@book_1.id}") do
+        click_link @book_1.title
+      end
+
+      expect(current_path).to eq(book_path(@book_1))
+    end
+
     it "I see an average review rating and amount of reviews on each book" do
       visit books_path
 


### PR DESCRIPTION
Book titles on the index page are now links to individual show pages.  We'll need to include this feature on the author show page when we get to it.  Closes #8 