### PR TITLE
Book Delete

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -41,9 +41,7 @@ class BooksController < ApplicationController
   end
 
   def add_authors(book)
-    create_authors.each do |author|
-      book.authors << author
-    end
+    book.authors << create_authors
   end
 
   def create_authors

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -34,6 +34,13 @@ class BooksController < ApplicationController
     end
   end
 
+  def destroy
+    @book = Book.destroy(params[:id])
+
+    flash.notice = "'#{@book.title}' was deleted."
+    redirect_to books_path
+  end
+
   private
 
   def book_params

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,6 @@
 class Book < ApplicationRecord
-  has_many :reviews
-  has_many :books_by_author
+  has_many :reviews, dependent: :destroy
+  has_many :books_by_author, dependent: :destroy
   has_many :authors, through: :books_by_author
 
   before_validation :titlecase_title

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -18,3 +18,5 @@
     </div>
     <% end %>
 </section>
+
+<%= link_to "Delete Book", book_path(@book), method: :delete, data: {confirm: "Are you sure you want to delete the book?"} %>

--- a/spec/features/books/index_spec.rb
+++ b/spec/features/books/index_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe "As a user", type: :feature do
 
     it "I'm able to navigate to a new book form" do
       visit books_path
+      
       click_link "Add a New Book"
 
       expect(current_path).to eq(new_book_path)

--- a/spec/features/books/show_spec.rb
+++ b/spec/features/books/show_spec.rb
@@ -69,10 +69,14 @@ RSpec.describe "as a user" do
       expect(page).to have_link("Delete Book")
     end
 
-    # describe "and click the 'Delete Book' link" do
-    #   it "it deletes the book and displays a confirmation message" do
-    #
-    #   end
-    # end
+    describe "and click the 'Delete Book' link" do
+      it "it displays a confirmation message" do
+        visit book_path(@book_1)
+
+        click_link "Delete Book"
+
+        expect(page).to have_content("Are you sure you want to delete the book?")
+      end
+    end
   end
 end

--- a/spec/features/books/show_spec.rb
+++ b/spec/features/books/show_spec.rb
@@ -70,12 +70,28 @@ RSpec.describe "as a user" do
     end
 
     describe "and click the 'Delete Book' link" do
-      it "it displays a confirmation message" do
+      it "it displays a confirmation message that the book has been deleted" do
         visit book_path(@book_1)
 
         click_link "Delete Book"
 
-        expect(page).to have_content("Are you sure you want to delete the book?")
+        expect(page).to have_content("'#{@book_1.title}' was deleted.")
+      end
+
+      it "it redirects me to /books" do
+        visit book_path(@book_1)
+
+        click_link "Delete Book"
+
+        expect(current_path).to eq(books_path)
+      end
+
+      it "I do not see the deleted book on the /books" do
+        visit book_path(@book_1)
+
+        click_link "Delete Book"
+
+        expect(page).to_not have_css("#book-#{@book_1.id}")
       end
     end
   end

--- a/spec/features/books/show_spec.rb
+++ b/spec/features/books/show_spec.rb
@@ -62,5 +62,17 @@ RSpec.describe "as a user" do
         end
       end
     end
+
+    it "it displays a link to delete the book" do
+      visit book_path(@book_1)
+
+      expect(page).to have_link("Delete Book")
+    end
+
+    # describe "and click the 'Delete Book' link" do
+    #   it "it deletes the book and displays a confirmation message" do
+    #
+    #   end
+    # end
   end
 end


### PR DESCRIPTION
Dear Brennan,

This PR add delete functionality from a book's show page.

- Add feature specs covering user experience on /books/show_spec.rb
- Add destroy action to BooksController with confirmation, flash notice and redirect
- Add 'Delete Book' link to view
- Add dependent destroy to Book model for Authors/Reviews

Also included is a minor refactor to the add_authors method in BooksController.

Closes #15 

Warm regards,