### PR TITLE
Delete Reviews

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -14,6 +14,14 @@ class ReviewsController < ApplicationController
     redirect_to books_path(book)
   end
 
+  def destroy
+    # This is very confusing, but our Review ID is passed into params as :book_id because Reviews are nested resources of Book
+    deleted_review = Review.find(params[:book_id])
+    deleted_review.destroy
+
+    redirect_to user_path(params[:id])
+  end
+
   private
 
   def review_params

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,6 +12,7 @@
       <h5><%= review.title %></h5>
       <p>Rating: <%= review.rating %></p>
       <p>Review: <%= review.text %></p>
+      <%= link_to "Delete Review", book_review_path(review), method: :delete, data: {confirm: "Are you sure you want to delete the review?"} %>
     </div>
   <% end %>
 </section>

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -90,5 +90,26 @@ RSpec.describe 'As a user', type: :feature do
       expect(review_2.title).to appear_before(review_1.title)
       expect(review_1.title).to appear_before(review_3.title)
     end
+
+    it 'I should be able to delete a review' do
+      visit user_path(@user)
+
+      within("#review-#{@review_1.id}") do
+        expect(page).to have_link("Delete Review")
+      end
+
+      within("#review-#{@review_2.id}") do
+        expect(page).to have_link("Delete Review")
+      end
+
+      within("#review-#{@review_3.id}") do
+        expect(page).to have_link("Delete Review")
+        click_link "Delete Review"
+      end
+
+      expect(current_path).to eq(user_path(@user))
+
+      expect(page).to_not have_css("#review-#{@review_3.id}")
+    end
   end
 end


### PR DESCRIPTION
This PR brings in the functionality to remove a Review from the database from our website. The option to delete is only present on the User who made the Review's show page.
Upon clicking the delete link, they will be given a warning and confirmation of their deletion. Upon confirming, they will be sent back to that User show page, where they will find the Review removed.
Since the Review table is a joins table between Books and Users, the Review will no longer show on the Book as well.

Resolves #16 