### PR TITLE
Author Show

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,0 +1,6 @@
+class AuthorsController < ApplicationController
+  def show
+    @author = Author.find(params[:id])
+    @books = @author.books
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -54,6 +54,10 @@ class Book < ApplicationRecord
     end
   end
 
+  def coauthors(current_author)
+    author_names - [current_author.name]
+  end
+
   private
 
   def titlecase_title

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,0 +1,10 @@
+<h2><%= @author.name %></h2>
+
+<% @books.each do |book| %>
+  <section id="book-<%= book.id %>-info">
+    <img src="<%= @book.image %>" alt="<%= book.title %>"/>
+    <p>Pages: <%= book.pages %></p>
+    <p>Published: <%= book.year %></p>
+
+  </section>
+<% end %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -6,6 +6,9 @@
     <h5><%= book.title %></h5>
     <p>Pages: <%= book.pages %></p>
     <p>Published: <%= book.year %></p>
+    <% if book.coauthors(@author).any? %>
+      <p>Co-authors: <%= book.coauthors(@author).join(', ') %></p>
+    <% end %>
 
   </section>
 <% end %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -2,7 +2,8 @@
 
 <% @books.each do |book| %>
   <section id="book-<%= book.id %>-info">
-    <img src="<%= @book.image %>" alt="<%= book.title %>"/>
+    <img src="<%= book.image %>" alt="<%= book.title %>"/>
+    <h5><%= book.title %></h5>
     <p>Pages: <%= book.pages %></p>
     <p>Published: <%= book.year %></p>
 

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -38,5 +38,21 @@ RSpec.describe 'As a user', type: :feature do
         expect(page).to have_content("Published: #{@book_3.year}")
       end
     end
+
+    it 'I should only see other authors listed under books' do
+      visit author_path(@flapjacks)
+
+      within("#book-#{@book_1.id}-info") do
+        expect(page).to have_content("Co-authors: Vincenzo 'Big' Cheese")
+      end
+
+      within("#book-#{@book_2.id}-info") do
+        expect(page).to_not have_content("Co-authors:")
+      end
+
+      within("#book-#{@book_3.id}-info") do
+        expect(page).to_not have_content("Co-authors:")
+      end
+    end
   end
 end

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe 'As a user', type: :feature do
       expect(page).to have_content(@flapjacks.name)
 
       within("#book-#{@book_1.id}-info") do
-        expect(page).to have_css("src=#{@book_1.image}")
+        expect(page).to have_css("img[src='#{@book_1.image}']")
         expect(page).to have_content(@book_1.title)
         expect(page).to have_content("Pages: #{@book_1.pages}")
         expect(page).to have_content("Published: #{@book_1.year}")
       end
 
       within("#book-#{@book_2.id}-info") do
-        expect(page).to have_css("src=#{@book_2.image}")
+        expect(page).to have_css("img[src='#{@book_2.image}']")
         expect(page).to have_content(@book_2.title)
         expect(page).to have_content("Pages: #{@book_2.pages}")
         expect(page).to have_content("Published: #{@book_2.year}")
       end
 
       within("#book-#{@book_3.id}-info") do
-        expect(page).to have_css("src=#{@book_3.image}")
+        expect(page).to have_css("img[src='#{@book_3.image}']")
         expect(page).to have_content(@book_3.title)
         expect(page).to have_content("Pages: #{@book_3.pages}")
         expect(page).to have_content("Published: #{@book_3.year}")

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'As a user', type: :feature do
+  describe 'When I visit an Authors show page' do
+    before :each do
+      @flapjacks = Author.create!(name: "Johnny Flapjacks")
+      @cheese = Author.create!(name: "Vincenzo 'Big' Cheese")
+
+      @book_1 = @flapjacks.books.create!(title: "Veronica Mars", pages: 10, year: 2012)
+      @book_2 = @flapjacks.books.create!(title: "Mars Aquatic", pages: 120, year: 1964)
+      @book_3 = @flapjacks.books.create!(title: "Trip to Mars", pages: 480, year: 2020)
+      @book_1.authors << @cheese
+
+    end
+
+    it 'I should be able to see all books and their information by that author'
+    visit author_path(@flapjacks)
+
+    expect(page).to have_content(@flapjacks.name)
+
+    within("#book-#{@book_1.id}-info") do
+      expect(page).to have_css("src=#{@book_1.image}")
+      expect(page).to have_content(@book_1.title)
+      expect(page).to have_content(@book_1.pages)
+      expect(page).to have_content(@book_1.year)
+    end
+
+    within("#book-#{@book_2.id}-info") do
+      expect(page).to have_css("src=#{@book_2.image}")
+      expect(page).to have_content(@book_2.title)
+      expect(page).to have_content(@book_2.pages)
+      expect(page).to have_content(@book_2.year)
+    end
+
+    within("#book-#{@book_3.id}-info") do
+      expect(page).to have_css("src=#{@book_3.image}")
+      expect(page).to have_content(@book_3.title)
+      expect(page).to have_content(@book_3.pages)
+      expect(page).to have_content(@book_3.year)
+    end
+  end
+end

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -21,22 +21,22 @@ RSpec.describe 'As a user', type: :feature do
     within("#book-#{@book_1.id}-info") do
       expect(page).to have_css("src=#{@book_1.image}")
       expect(page).to have_content(@book_1.title)
-      expect(page).to have_content(@book_1.pages)
-      expect(page).to have_content(@book_1.year)
+      expect(page).to have_content("Pages: #{@book_1.pages}")
+      expect(page).to have_content("Published: #{@book_1.year}")
     end
 
     within("#book-#{@book_2.id}-info") do
       expect(page).to have_css("src=#{@book_2.image}")
       expect(page).to have_content(@book_2.title)
-      expect(page).to have_content(@book_2.pages)
-      expect(page).to have_content(@book_2.year)
+      expect(page).to have_content("Pages: #{@book_2.pages}")
+      expect(page).to have_content("Published: #{@book_2.year}")
     end
 
     within("#book-#{@book_3.id}-info") do
       expect(page).to have_css("src=#{@book_3.image}")
       expect(page).to have_content(@book_3.title)
-      expect(page).to have_content(@book_3.pages)
-      expect(page).to have_content(@book_3.year)
+      expect(page).to have_content("Pages: #{@book_3.pages}")
+      expect(page).to have_content("Published: #{@book_3.year}")
     end
   end
 end

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -10,33 +10,33 @@ RSpec.describe 'As a user', type: :feature do
       @book_2 = @flapjacks.books.create!(title: "Mars Aquatic", pages: 120, year: 1964)
       @book_3 = @flapjacks.books.create!(title: "Trip to Mars", pages: 480, year: 2020)
       @book_1.authors << @cheese
-
     end
 
-    it 'I should be able to see all books and their information by that author'
-    visit author_path(@flapjacks)
+    it 'I should be able to see all books and their information by that author' do
+      visit author_path(@flapjacks)
 
-    expect(page).to have_content(@flapjacks.name)
+      expect(page).to have_content(@flapjacks.name)
 
-    within("#book-#{@book_1.id}-info") do
-      expect(page).to have_css("src=#{@book_1.image}")
-      expect(page).to have_content(@book_1.title)
-      expect(page).to have_content("Pages: #{@book_1.pages}")
-      expect(page).to have_content("Published: #{@book_1.year}")
-    end
+      within("#book-#{@book_1.id}-info") do
+        expect(page).to have_css("src=#{@book_1.image}")
+        expect(page).to have_content(@book_1.title)
+        expect(page).to have_content("Pages: #{@book_1.pages}")
+        expect(page).to have_content("Published: #{@book_1.year}")
+      end
 
-    within("#book-#{@book_2.id}-info") do
-      expect(page).to have_css("src=#{@book_2.image}")
-      expect(page).to have_content(@book_2.title)
-      expect(page).to have_content("Pages: #{@book_2.pages}")
-      expect(page).to have_content("Published: #{@book_2.year}")
-    end
+      within("#book-#{@book_2.id}-info") do
+        expect(page).to have_css("src=#{@book_2.image}")
+        expect(page).to have_content(@book_2.title)
+        expect(page).to have_content("Pages: #{@book_2.pages}")
+        expect(page).to have_content("Published: #{@book_2.year}")
+      end
 
-    within("#book-#{@book_3.id}-info") do
-      expect(page).to have_css("src=#{@book_3.image}")
-      expect(page).to have_content(@book_3.title)
-      expect(page).to have_content("Pages: #{@book_3.pages}")
-      expect(page).to have_content("Published: #{@book_3.year}")
+      within("#book-#{@book_3.id}-info") do
+        expect(page).to have_css("src=#{@book_3.image}")
+        expect(page).to have_content(@book_3.title)
+        expect(page).to have_content("Pages: #{@book_3.pages}")
+        expect(page).to have_content("Published: #{@book_3.year}")
+      end
     end
   end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe Book, type: :model do
       expect(@book_1.review_count).to eq(2)
       expect(@book_2.review_count).to eq(1)
     end
+
+    it ".coauthors" do
+      expect(@book_1.coauthors(@author_1)).to eq(["Bob"])
+      expect(@book_1.coauthors(@author_2)).to eq(["Jim"])
+    end
   end
 
   describe 'class methods' do


### PR DESCRIPTION
This PR brings in the functionality of an Author show page. Author show pages will contain all the pertinent information about that Author and their Books.
Each of their Books will be sectioned off, including their image, title, number of pages, year published and any other Co-authors.
Co-authors will only display if the book has multiple authors. Only the authors who are NOT the currently shown author will display.

Resolves #28 