### PR TITLE
Author Delete

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -7,4 +7,11 @@ class AuthorsController < ApplicationController
     @author = Author.find(params[:id])
     @books = @author.books
   end
+
+  def destroy
+    @author = Author.destroy(params[:id])
+
+    flash.notice = "'#{@author.name}' was deleted."
+    redirect_to books_path
+  end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,5 +1,5 @@
 class Author < ApplicationRecord
-  has_many :books_by_author
+  has_many :books_by_author, dependent: :destroy
   has_many :books, through: :books_by_author
 
   validates_presence_of :name

--- a/app/models/books_by_author.rb
+++ b/app/models/books_by_author.rb
@@ -1,4 +1,4 @@
 class BooksByAuthor < ApplicationRecord
-  belongs_to :book
+  belongs_to :book, dependent: :destroy
   belongs_to :author
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -21,3 +21,5 @@
 
   </section>
 <% end %>
+
+<%= link_to "Delete Author", author_path(@author), method: :delete, data: {confirm: "Are you sure you want to delete the author?"} %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -25,7 +25,8 @@
   </section>
 </section>
 
-<% @books.each do |book| %>
+<section id="all-books">
+  <% @books.each do |book| %>
   <section class="book" id="book-<%= book.id %>">
     <img src="<%= book.image %>" alt="<%= book.title %> Cover">
     <h5><%= link_to book.title, book_path(book) %></h5>
@@ -34,6 +35,7 @@
     <p>Pages: <%= book.pages %></p>
     <p>Year Published: <%= book.year %></p>
   </section>
-<% end %>
+  <% end %>
+</section>
 
 <%= link_to "Add a New Book", new_book_path %>

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -70,5 +70,41 @@ RSpec.describe 'As a user', type: :feature do
         expect(page).to have_content("Posted by: #{@review_1.user.name}")
       end
     end
+
+    describe "and click the 'Delete Author' link" do
+      it "it displays a confirmation message that the author has been deleted" do
+        visit author_path(@flapjacks)
+
+        click_link "Delete Author"
+
+        expect(page).to have_content("'#{@flapjacks.name}' was deleted.")
+      end
+
+      it "it redirects me to /books" do
+        visit author_path(@flapjacks)
+
+        click_link "Delete Author"
+
+        expect(current_path).to eq(books_path)
+      end
+
+      it "I do not see the deleted author on the /books" do
+        visit author_path(@flapjacks)
+
+        click_link "Delete Author"
+
+        expect(page).to_not have_content(@flapjacks.name)
+      end
+
+      it 'also deletes all books attached to this author' do
+        visit author_path(@flapjacks)
+
+        click_link "Delete Author"
+
+        @flapjacks.books.each do |book|
+          expect(page).to_not have_css("#book-#{book.id}")
+        end
+      end
+    end
   end
 end

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -93,7 +93,13 @@ RSpec.describe 'As a user', type: :feature do
 
         click_link "Delete Author"
 
-        expect(page).to_not have_content(@flapjacks.name)
+        within("#book-stats") do
+          expect(page).to_not have_content(@flapjacks.name)
+        end
+
+        within("#all-books") do
+          expect(page).to_not have_content(@flapjacks.name)
+        end
       end
 
       it 'also deletes all books attached to this author' do


### PR DESCRIPTION
This PR brings in the functionality to delete an Author. This is done on that Author's show page, with a link at the bottom, similar to the Book show page.
Once an Author has been confirmed to be deleted, it will delete all references to that Author, and also all Books they are attached to. This includes Books that were only co-authored by that Author, leaving the co-Author lonely.