### PR TITLE
Show Page Links

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,10 +8,6 @@ class Book < ApplicationRecord
   validates :title, :pages, :year, presence: true
   validates :title, uniqueness: true
 
-  def author_names
-    authors.pluck(:name)
-  end
-
   def average_rating
     rating = reviews.average(:rating)
     rating = 0 if rating == nil
@@ -71,7 +67,7 @@ class Book < ApplicationRecord
   end
 
   def coauthors(current_author)
-    author_names - [current_author.name]
+    authors - [current_author]
   end
 
   private

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -7,7 +7,12 @@
     <p>Pages: <%= book.pages %></p>
     <p>Published: <%= book.year %></p>
     <% if book.coauthors(@author).any? %>
-      <p>Co-authors: <%= book.coauthors(@author).join(', ') %></p>
+      <p>Co-authors:</p>
+        <% book.coauthors(@author).each do |coauthor| %>
+        <ul>
+          <li><%= link_to coauthor.name, author_path(coauthor) %></li>
+        </ul>
+        <% end %>
     <% end %>
     <% if book.highest_three_reviews.any? %>
     <% top_review = book.highest_three_reviews.first %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -15,10 +15,9 @@
       <ul>
         <li><%= top_review.title %></li>
         <li><%= top_review.rating %> Stars</li>
-        <li>Posted by: <%= top_review.user.name %></li>
+        <li>Posted by: <%= link_to top_review.user.name, user_path(top_review.user) %></li>
       </ul>
     <% end %>
-
   </section>
 <% end %>
 

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -31,7 +31,12 @@
     <img src="<%= book.image %>" alt="<%= book.title %> Cover">
     <h5><%= link_to book.title, book_path(book) %></h5>
     <p>Average Rating: <%= book.average_rating %> (<%= book.review_count %>)</p>
-    <p><%= book.author_names.join(", ") %></p>
+    <p>Authors:</p>
+    <ul>
+      <% book.authors.each do |author| %>
+        <li><%= link_to author.name, author_path(author) %></li>
+        <% end %>
+    </ul>
     <p>Pages: <%= book.pages %></p>
     <p>Year Published: <%= book.year %></p>
   </section>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -5,7 +5,12 @@
 <section id="book-<%= @book.id %>-info">
   <p>Pages: <%= @book.pages %></p>
   <p>Published: <%= @book.year %></p>
-  <p>Author(s): <%= @book.author_names.join(", ") %></p>
+  <p>Author(s):</p>
+    <ul>
+      <% @book.authors.each do |author| %>
+        <li><%= link_to author.name, author_path(author) %></li>
+        <% end %>
+    </ul>
 </section>
 
 <section id="review-stats">

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe 'As a user', type: :feature do
       end
     end
 
+    it "I should see the username associated with the top review as a link" do
+      @user_1 = User.create!(name: "Anony-moose")
+      @user_2 = User.create!(name: "VinnyCheeseFan")
+
+      @review_1 = @book_1.reviews.create!(text: "THIS BOOK IS AWESOME!", rating: 5, user: @user_1)
+      @review_2 = @book_1.reviews.create!(text: "This book didn't do it for me.", rating: 1, user: @user_2)
+
+      visit author_path(@flapjacks)
+
+      within("#book-#{@book_1.id}-info") do
+        expect(page).to have_link(@review_1.user.name)
+      end
+    end
+
     describe "and click the 'Delete Author' link" do
       it "it displays a confirmation message that the author has been deleted" do
         visit author_path(@flapjacks)

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe 'As a user', type: :feature do
       end
     end
 
+    it "I'm able to visit the top reviewer's show page by clicking their username" do
+      @user_1 = User.create!(name: "Anony-moose")
+      @user_2 = User.create!(name: "VinnyCheeseFan")
+
+      @review_1 = @book_1.reviews.create!(text: "THIS BOOK IS AWESOME!", rating: 5, user: @user_1)
+      @review_2 = @book_1.reviews.create!(text: "This book didn't do it for me.", rating: 1, user: @user_2)
+
+      visit author_path(@flapjacks)
+
+      within("#book-#{@book_1.id}-info") do
+        click_link @review_1.user.name
+      end
+      
+      expect(current_path).to eq(user_path(@review_1.user.id))
+    end
+
     describe "and click the 'Delete Author' link" do
       it "it displays a confirmation message that the author has been deleted" do
         visit author_path(@flapjacks)

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'As a user', type: :feature do
       visit author_path(@flapjacks)
 
       within("#book-#{@book_1.id}-info") do
-        expect(page).to have_content("Co-authors: Vincenzo 'Big' Cheese")
+        expect(page).to have_link("Vincenzo 'Big' Cheese")
       end
 
       within("#book-#{@book_2.id}-info") do
@@ -97,7 +97,7 @@ RSpec.describe 'As a user', type: :feature do
       within("#book-#{@book_1.id}-info") do
         click_link @review_1.user.name
       end
-      
+
       expect(current_path).to eq(user_path(@review_1.user.id))
     end
 

--- a/spec/features/books/index_spec.rb
+++ b/spec/features/books/index_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe "As a user", type: :feature do
         expect(page).to have_css("img[src='#{@book_1.image}']")
 
         expect(page).to have_content(@book_1.title)
-        expect(page).to have_content(@book_1.authors[0].name)
-        expect(page).to have_content(@book_1.authors[1].name)
+        expect(page).to have_link(@book_1.authors[0].name)
+        expect(page).to have_link(@book_1.authors[1].name)
         expect(page).to have_content(@book_1.pages)
         expect(page).to have_content(@book_1.year)
       end
@@ -65,7 +65,7 @@ RSpec.describe "As a user", type: :feature do
         expect(page).to have_css("img[src='#{@book_2.image}']")
 
         expect(page).to have_content(@book_2.title)
-        expect(page).to have_content(@book_2.authors[0].name)
+        expect(page).to have_link(@book_2.authors[0].name)
         expect(page).to have_content(@book_2.pages)
         expect(page).to have_content(@book_2.year)
       end
@@ -74,7 +74,7 @@ RSpec.describe "As a user", type: :feature do
         expect(page).to have_css("img[src='#{@book_3.image}']")
 
         expect(page).to have_content(@book_3.title)
-        expect(page).to have_content(@book_3.authors[0].name)
+        expect(page).to have_link(@book_3.authors[0].name)
         expect(page).to have_content(@book_3.pages)
         expect(page).to have_content(@book_3.year)
       end

--- a/spec/features/books/show_spec.rb
+++ b/spec/features/books/show_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe "as a user" do
       expect(page).to have_css("img[src='#{@book_1.image}']")
 
       within("#book-#{@book_1.id}-info") do
-        expect(page).to have_link("Author(s): #{@author_1.name}, #{@author_4.name}")
+        expect(page).to have_link("#{@author_1.name}")
+        expect(page).to have_link("#{@author_4.name}")
         expect(page).to have_content("Pages: #{@book_1.pages}")
         expect(page).to have_content("Published: #{@book_1.year}")
       end
@@ -47,7 +48,7 @@ RSpec.describe "as a user" do
       visit book_path(@book_1)
 
       expect(page).to_not have_content(@book_2.title)
-      expect(page).to_not have_link("Author(s): #{@author_2.name}")
+      expect(page).to_not have_link("#{@author_2.name}")
       expect(page).to_not have_content("Pages: #{@book_2.pages}")
       expect(page).to_not have_content("Published: #{@book_2.year}")
       # expect(page).to_not have_css("img[src='#{@book_2.image}']")

--- a/spec/features/books/show_spec.rb
+++ b/spec/features/books/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "as a user" do
       expect(page).to have_css("img[src='#{@book_1.image}']")
 
       within("#book-#{@book_1.id}-info") do
-        expect(page).to have_content("Author(s): #{@author_1.name}, #{@author_4.name}")
+        expect(page).to have_link("Author(s): #{@author_1.name}, #{@author_4.name}")
         expect(page).to have_content("Pages: #{@book_1.pages}")
         expect(page).to have_content("Published: #{@book_1.year}")
       end
@@ -47,7 +47,7 @@ RSpec.describe "as a user" do
       visit book_path(@book_1)
 
       expect(page).to_not have_content(@book_2.title)
-      expect(page).to_not have_content("Author(s): #{@author_2.name}")
+      expect(page).to_not have_link("Author(s): #{@author_2.name}")
       expect(page).to_not have_content("Pages: #{@book_2.pages}")
       expect(page).to_not have_content("Published: #{@book_2.year}")
       # expect(page).to_not have_css("img[src='#{@book_2.image}']")

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -37,11 +37,6 @@ RSpec.describe Book, type: :model do
       @review_7 = @book_1.reviews.create!(title: "This Book Blows", text: "This book should get blown away.", rating: 1, user: @user_6)
     end
 
-    it "#author_names" do
-      expect(@book_1.author_names).to eq(["Jim", "Bob"])
-      expect(@book_2.author_names).to eq(["Bob"])
-    end
-
     it "#average_rating" do
       expect(@book_1.average_rating).to eq(3.0)
       expect(@book_2.average_rating).to eq(2.0)
@@ -62,8 +57,8 @@ RSpec.describe Book, type: :model do
     end
 
     it "#coauthors" do
-      expect(@book_1.coauthors(@author_1)).to eq(["Bob"])
-      expect(@book_1.coauthors(@author_2)).to eq(["Jim"])
+      expect(@book_1.coauthors(@author_1)).to eq([@author_2])
+      expect(@book_1.coauthors(@author_2)).to eq([@author_1])
     end
   end
 


### PR DESCRIPTION
This PR turns all author, coauthor and user names into links throughout the app.  To accomplish this:

- Book model coauthor method was refactored to return an array of objects rather than an array of strings
- Book model author_names method was removed, along with all dependent tests
- Author/coauthor appearances have been converted to unordered list items rather than comma separated values

Resolves #5 , #6 