### PR TITLE
New Book Form Fix

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -62,7 +62,7 @@ class BooksController < ApplicationController
   end
 
   def split_authors
-    params[:book][:authors].split(", ")
+    params[:authors][:name].split(", ")
   end
 
   def find_order(value)

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -3,6 +3,7 @@ class Author < ApplicationRecord
   has_many :books, through: :books_by_author
 
   validates_presence_of :name
+  validates :name, uniqueness: true
 
   def book_count
     books.count

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -4,14 +4,19 @@
   <%= form_for @book do |f| %>
     <%= f.label :title, "Title:" %>
     <%= f.text_field :title %>
+
     <%= f.label :pages, "Number of Pages:" %>
     <%= f.text_field :pages %>
+
     <%= f.label :year, "Year Published:" %>
     <%= f.text_field :year %>
+
     <%= f.label :authors, "Author(s):" %>
     <%= f.text_field :authors %>
+
     <%= f.label :image, "Image URL:" %>
     <%= f.text_field :image %>
+
     <%= f.submit "Add Book" %>
   <% end %>
 </section>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -15,7 +15,7 @@
     <%= text_field :authors, :name %>
 
     <%= f.label :image, "Image URL:" %>
-    <%= f.text_field :image %>
+    <%= f.text_field :image, value: "" %>
 
     <%= f.submit "Add Book" %>
   <% end %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -11,8 +11,8 @@
     <%= f.label :year, "Year Published:" %>
     <%= f.text_field :year %>
 
-    <%= f.label :authors, "Author(s):" %>
-    <%= f.text_field :authors %>
+    <%= label :authors, :name, "Author(s):" %>
+    <%= text_field :authors, :name %>
 
     <%= f.label :image, "Image URL:" %>
     <%= f.text_field :image %>


### PR DESCRIPTION
This PR cleans up the new book form.  ActiveRecord::Relation no longer displays in the "Author(s):" text field, and "assets/default.png" no longer displays in the "Image:" field.  Also refactored split_authors method in the BooksController to use author: name params rather than book: authors.